### PR TITLE
Update signature scheme from G2Basic to G2ProofOfPossession

### DIFF
--- a/utils/genver.py
+++ b/utils/genver.py
@@ -1,4 +1,4 @@
-from py_ecc.bls import G2Basic as bls_basic
+from py_ecc.bls import G2ProofOfPossession as bls_basic
 import py_ecc.optimized_bls12_381 as bls_curve
 import py_ecc.bls.g2_primatives as bls_conv
 


### PR DESCRIPTION
ETH beacon chain expects `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` but this tool uses `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_`. This updates the tool to sign with the former and allow for, e.g., signing `BLSToExecutionChange`s.